### PR TITLE
Gate to arm only devices and fix nitpicks.

### DIFF
--- a/AntiEmulator/AndroidManifest.xml
+++ b/AntiEmulator/AndroidManifest.xml
@@ -3,7 +3,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     package="diff.strazzere.anti">
 
-    <uses-sdk android:minSdkVersion="16"
+    <uses-sdk android:minSdkVersion="21"
         android:targetSdkVersion="23"
         android:maxSdkVersion="29" />
     <uses-permission android:name="android.permission.READ_PHONE_STATE" />
@@ -12,6 +12,7 @@
     <application
         android:allowBackup="false"
         android:icon="@drawable/ic_launcher"
+
         android:label="@string/app_name"
         android:theme="@style/AppTheme">
         <activity

--- a/AntiEmulator/AntiEmulator.iml
+++ b/AntiEmulator/AntiEmulator.iml
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module external.linked.project.id=":AntiEmulator" external.linked.project.path="$MODULE_DIR$" external.root.project.path="$MODULE_DIR$/.." external.system.id="GRADLE" type="JAVA_MODULE" version="4">
+  <component name="FacetManager">
+    <facet type="android-gradle" name="Android-Gradle">
+      <configuration>
+        <option name="GRADLE_PROJECT_PATH" value=":AntiEmulator" />
+        <option name="LAST_SUCCESSFUL_SYNC_AGP_VERSION" value="3.5.0" />
+        <option name="LAST_KNOWN_AGP_VERSION" value="3.5.0" />
+      </configuration>
+    </facet>
+    <facet type="android" name="Android">
+      <configuration>
+        <option name="SELECTED_BUILD_VARIANT" value="debug" />
+        <option name="ASSEMBLE_TASK_NAME" value="assembleDebug" />
+        <option name="COMPILE_JAVA_TASK_NAME" value="compileDebugSources" />
+        <afterSyncTasks>
+          <task>generateDebugSources</task>
+        </afterSyncTasks>
+        <option name="ALLOW_USER_CONFIGURATION" value="false" />
+        <option name="RES_FOLDERS_RELATIVE_PATH" value="file://$MODULE_DIR$/res;file://$MODULE_DIR$/build/generated/res/rs/debug;file://$MODULE_DIR$/build/generated/res/resValues/debug" />
+        <option name="TEST_RES_FOLDERS_RELATIVE_PATH" value="" />
+      </configuration>
+    </facet>
+  </component>
+  <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_7">
+    <output url="file://$MODULE_DIR$/build/intermediates/javac/debug/classes" />
+    <output-test url="file://$MODULE_DIR$/build/intermediates/javac/debugUnitTest/classes" />
+    <exclude-output />
+    <content url="file://$MODULE_DIR$">
+      <sourceFolder url="file://$MODULE_DIR$/build/generated/ap_generated_sources/debug/out" isTestSource="false" generated="true" />
+      <sourceFolder url="file://$MODULE_DIR$/build/generated/aidl_source_output_dir/debug/compileDebugAidl/out" isTestSource="false" generated="true" />
+      <sourceFolder url="file://$MODULE_DIR$/build/generated/source/buildConfig/debug" isTestSource="false" generated="true" />
+      <sourceFolder url="file://$MODULE_DIR$/build/generated/renderscript_source_output_dir/debug/compileDebugRenderscript/out" isTestSource="false" generated="true" />
+      <sourceFolder url="file://$MODULE_DIR$/build/generated/res/rs/debug" type="java-resource" generated="true" />
+      <sourceFolder url="file://$MODULE_DIR$/build/generated/res/resValues/debug" type="java-resource" generated="true" />
+      <sourceFolder url="file://$MODULE_DIR$/build/generated/ap_generated_sources/debugAndroidTest/out" isTestSource="true" generated="true" />
+      <sourceFolder url="file://$MODULE_DIR$/build/generated/aidl_source_output_dir/debugAndroidTest/compileDebugAndroidTestAidl/out" isTestSource="true" generated="true" />
+      <sourceFolder url="file://$MODULE_DIR$/build/generated/source/buildConfig/androidTest/debug" isTestSource="true" generated="true" />
+      <sourceFolder url="file://$MODULE_DIR$/build/generated/renderscript_source_output_dir/debugAndroidTest/compileDebugAndroidTestRenderscript/out" isTestSource="true" generated="true" />
+      <sourceFolder url="file://$MODULE_DIR$/build/generated/res/rs/androidTest/debug" type="java-test-resource" generated="true" />
+      <sourceFolder url="file://$MODULE_DIR$/build/generated/res/resValues/androidTest/debug" type="java-test-resource" generated="true" />
+      <sourceFolder url="file://$MODULE_DIR$/build/generated/ap_generated_sources/debugUnitTest/out" isTestSource="true" generated="true" />
+      <sourceFolder url="file://$MODULE_DIR$/build-types/debug/res" type="java-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/build-types/debug/resources" type="java-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/build-types/debug/assets" type="java-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/build-types/debug/aidl" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/build-types/debug/java" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/build-types/debug/rs" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/build-types/debug/shaders" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTestDebug/res" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTestDebug/resources" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTestDebug/assets" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTestDebug/aidl" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTestDebug/java" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTestDebug/rs" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTestDebug/shaders" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/testDebug/res" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/testDebug/resources" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/testDebug/assets" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/testDebug/aidl" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/testDebug/java" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/testDebug/rs" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/testDebug/shaders" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/res" type="java-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src" type="java-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/assets" type="java-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/src/main/shaders" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/res" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/resources" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/assets" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/aidl" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/java" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/rs" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/shaders" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test/res" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test/resources" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test/assets" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test/aidl" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test/java" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test/rs" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test/shaders" isTestSource="true" />
+      <excludeFolder url="file://$MODULE_DIR$/build" />
+    </content>
+    <orderEntry type="jdk" jdkName="Android API 29 Platform" jdkType="Android SDK" />
+    <orderEntry type="sourceFolder" forTests="false" />
+    <orderEntry type="library" name="Gradle: __local_aars__:/home/diff/repo/android/anti-emulator/AntiEmulator/libs/android-support-v4.jar:unspecified@jar" level="project" />
+  </component>
+</module>

--- a/AntiEmulator/build.gradle
+++ b/AntiEmulator/build.gradle
@@ -7,7 +7,7 @@ android {
 
     defaultConfig {
         applicationId "diff.strazzere.anti"
-        minSdkVersion 14
+        minSdkVersion 21
         targetSdkVersion 29
         versionCode 1
         versionName "1.0"

--- a/AntiEmulator/jni/Application.mk
+++ b/AntiEmulator/jni/Application.mk
@@ -4,6 +4,6 @@ include $(CLEAR_VARS)
 
 APP_ABI := armeabi-v7a
 
-APP_PLATFORM := android-16
+APP_PLATFORM := android-21
 
 include $(BUILD_SHARED_LIBRARY)

--- a/AntiEmulator/jni/anti.c
+++ b/AntiEmulator/jni/anti.c
@@ -1,12 +1,13 @@
 /*
  * Fun with qemu arm issues
  *
- * <diff@lookout.com>
+ * <diff@protonmail.com>
  */
 
 #include <stdlib.h> // avoid exit warning
 #include <signal.h> // sigtrap stuff, duh
 #include <sys/wait.h> // for waitpid
+#include <unistd.h> // fork() / sleep()
 #include <jni.h>
 
 void handler_sigtrap(int signo) {
@@ -17,7 +18,7 @@ void handler_sigbus(int signo) {
   exit(-1);
 }
 
-int setupSigTrap() {
+void setupSigTrap() {
   // BKPT throws SIGTRAP on nexus 5 / oneplus one (and most devices)
   signal(SIGTRAP, handler_sigtrap);
   // BKPT throws SIGBUS on nexus 4
@@ -25,7 +26,7 @@ int setupSigTrap() {
 }
 
 // This will cause a SIGSEGV on some QEMU or be properly respected
-int tryBKPT() {
+void tryBKPT() {
   __asm__ __volatile__ ("bkpt 255");
 }
 

--- a/AntiEmulator/src/diff/strazzere/anti/MainActivity.java
+++ b/AntiEmulator/src/diff/strazzere/anti/MainActivity.java
@@ -1,6 +1,7 @@
 package diff.strazzere.anti;
 
 import android.app.Activity;
+import android.os.Build;
 import android.os.Bundle;
 import android.util.Log;
 import android.view.Menu;
@@ -51,7 +52,11 @@ public class MainActivity extends Activity {
         log("hasQEmuFiles : " + FindEmulator.hasQEmuFiles());
         log("hasGenyFiles : " + FindEmulator.hasGenyFiles());
         log("hasEmulatorAdb :" + FindEmulator.hasEmulatorAdb());
-        log("hitsQemuBreakpoint : " + FindEmulator.checkQemuBreakpoint());
+        for(String abi : Build.SUPPORTED_ABIS) {
+            if (abi.equalsIgnoreCase("armeabi-v7a")) {
+                log("hitsQemuBreakpoint : " + FindEmulator.checkQemuBreakpoint());
+            }
+        }
         if (FindEmulator.hasKnownDeviceId(getApplicationContext())
                         || FindEmulator.hasKnownImsi(getApplicationContext())
                         || FindEmulator.hasEmulatorBuild(getApplicationContext())

--- a/AntiEmulator/src/diff/strazzere/anti/debugger/FindDebugger.java
+++ b/AntiEmulator/src/diff/strazzere/anti/debugger/FindDebugger.java
@@ -63,7 +63,7 @@ public class FindDebugger {
      * 
      * @throws IOException
      */
-    public static boolean hasAdbInEmulator() throws IOException {
+    public static boolean  hasAdbInEmulator() throws IOException {
         boolean adbInEmulator = false;
         BufferedReader reader = null;
         try {

--- a/AntiEmulator/src/diff/strazzere/anti/emulator/FindEmulator.java
+++ b/AntiEmulator/src/diff/strazzere/anti/emulator/FindEmulator.java
@@ -1,6 +1,7 @@
 package diff.strazzere.anti.emulator;
 
 import android.content.Context;
+import android.os.Build;
 import android.telephony.TelephonyManager;
 import android.util.Log;
 
@@ -60,8 +61,13 @@ public class FindEmulator {
     private static int MIN_PROPERTIES_THRESHOLD = 0x5;
 
     static {
-        // This is only valid for arm
-        System.loadLibrary("anti");
+        // This is only valid for arm, so gate it
+        for(String abi : Build.SUPPORTED_ABIS) {
+            if(abi.equalsIgnoreCase("armeabi-v7a")) {
+                System.loadLibrary("anti");
+                break;
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
There could potentially be issues with the native library being
loaded on things not compatible with `armeabi-v7a`. The library
should not be loaded and the code won't be called if this is the case.
This should close issue #12.

Due to an API I'm using to do the above gating, the minimum is getting
bumped from `android-16` to `android-21` now.

Also fixed some implicite declarations and bad return types in the c
code.